### PR TITLE
Updates for crontabs

### DIFF
--- a/scripts/default/enshrouded-bootstrap-shared
+++ b/scripts/default/enshrouded-bootstrap-shared
@@ -9,6 +9,8 @@ prepareEnshroudedAppFolders() {
 initCrontab() {
   crontab=$(mktemp)
 
+  crontab -l >"$crontab" 2>/dev/null
+
   if [ -n "$UPDATE_CRON" ]; then
     debug "creating cron for update checks (schedule: $UPDATE_CRON)"
     echo "$UPDATE_CRON supervisorctl start enshrouded-updater >/dev/null 2>&1" >>"$crontab"

--- a/scripts/default/enshrouded-restart-server
+++ b/scripts/default/enshrouded-restart-server
@@ -1,0 +1,13 @@
+#!/bin/bash
+. "$(dirname "$0")/common"
+. "$(dirname "$0")/defaults"
+
+main() {
+  info "Stopping enshrouded server"
+  supervisorctl stop enshrouded-server
+
+  info "Stop container for a clean start"
+  kill -INT $(cat /var/run/supervisord.pid)
+}
+
+main


### PR DESCRIPTION
* Don't blow away existing crontabs during `initCrontab()` - allows for cron jobs to be created during BOOTSTRAP_HOOK
* Added a simple script to restart the server